### PR TITLE
Changing python3-venv to python3.4-venv in the apt-gets.txt file

### DIFF
--- a/apt-gets.txt
+++ b/apt-gets.txt
@@ -1,6 +1,6 @@
 python3-dev
 python3-pip
-python3-venv
+python3.4-venv
 rabbitmq-server
 liblapack-dev
 gfortran


### PR DESCRIPTION
Changing python3-venv to python3.4-venv in the apt-gets.txt file so that apt-get install will work without failing.
OS => Ubuntu 14.04.4